### PR TITLE
Fix cookiearg in no-debug and remove tempfile

### DIFF
--- a/check_curl.sh
+++ b/check_curl.sh
@@ -175,8 +175,12 @@ if [ $debug -eq 1 ]; then
   exit 0
 else
   start=$(echo $(($(date +%s%N)/1000000)))
-  body=$(eval $curl --no-keepalive -s $insecurearg $proxyarg $followarg $bodyarg $headerarg -X $method "$url")
+  body=$(eval $curl --no-keepalive -s $insecurearg $proxyarg $followarg $bodyarg $headerarg -X $method $cookiesarg "$url")
   status=$?
+fi
+
+if [ $cookies -eq 1 ] ; then
+  rm -f ${COOKIE_JAR_TEMP_PATH}
 fi
 
 end=$(echo $(($(date +%s%N)/1000000)))


### PR DESCRIPTION
This fixes that the cookiearg will also be used in non-debug mode and it will remove the tempfile after the curl